### PR TITLE
Changed good_lp to import microlp rather than minilp, updated src/utilities/minimize_l1.rs to reflect this

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ auto_impl = "0.4.1"
 # debugit = "0.2.0" # this only works with nightly
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
-good_lp = { version = "1.4.0", features = ["minilp"], default-features = false }
+good_lp = { version = "1.4.0", features = ["microlp"], default-features = false }
 grb = { version = "1.3.0", optional = true }
 indicatif = "0.17.2"
 itertools = "0.10.0"

--- a/src/utilities/optimization/minimize_l1.rs
+++ b/src/utilities/optimization/minimize_l1.rs
@@ -20,7 +20,7 @@
 //!                 y and x are unconstrained continuous variables
 //! ```
 
-use good_lp::{SolverModel, Solution, minilp, Expression, Variable, ProblemVariables};
+use good_lp::{SolverModel, Solution, Expression, Variable, ProblemVariables};
 
 use itertools::Itertools;
 use num::ToPrimitive;
@@ -251,7 +251,8 @@ pub fn minimize_l1<
     // form the model
     let mut problem     =   variables
                             .minimise( objective.clone() )
-                            .using( minilp );
+                            // .using( minilp );
+                            .using(good_lp::microlp);
 
     // add constraints
     for row in key_to_row.values() {
@@ -426,7 +427,7 @@ pub fn minimize_l1_kernel<
     // form the model
     let mut problem     =   variables
                             .minimise( objective.clone() )
-                            .using( minilp );
+                            .using(good_lp::microlp);
 
     // add constraints
     for col in key_to_col.values() {


### PR DESCRIPTION
Changed good_lp to import microlp rather than minilp, updated src/utilities/minimize_l1.rs to reflect this. Latest version of crate `good_lp` 1.10.0, as included in Cargo.toml, does not include feature `minilp`, but it does include feature flag `microlp`. Updated feature flag and file to use this alternate solver. 